### PR TITLE
feat: k8s 매니페스트 파일 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Terraform template
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+### Ansible template
+*.retry
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+#environment
+# Kubernetes Secrets
+*-secret.yaml
+*-secrets.yaml
+*secret*.yaml
+*secrets*.yaml
+
+# Environment files
+.env
+.env.*
+*.env
+# Additional secret patterns (optional)
+**/*secret*
+**/*secrets*
+

--- a/kubernetes/backend/backend-deployment.yaml
+++ b/kubernetes/backend/backend-deployment.yaml
@@ -1,0 +1,52 @@
+# ktb-bootcampchat-backend-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktb-bootcampchat-backend
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: backend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: ktb-bootcampchat
+      component: backend
+  template:
+    metadata:
+      labels:
+        app: ktb-bootcampchat
+        component: backend
+    spec:
+      containers:
+        - name: ktb-bootcampchat-backend
+          image: ktb-bootcampchat/backend:latest
+          ports:
+            - containerPort: 5000
+            - containerPort: 8081
+              name: websocket
+          envFrom:
+            - configMapRef:
+                name: ktb-bootcampchat-config
+            - secretRef:
+                name: ktb-bootcampchat-secret
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 5

--- a/kubernetes/backend/backend-service.yaml
+++ b/kubernetes/backend/backend-service.yaml
@@ -1,0 +1,31 @@
+# ktb-bootcampchat-backend-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-backend
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: backend
+spec:
+  selector:
+    app: ktb-bootcampchat
+    component: backend
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 5000
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 5000
+      protocol: TCP
+    - name: websocket
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800

--- a/kubernetes/backend/messaging/kafka/kafka-deployment.yaml
+++ b/kubernetes/backend/messaging/kafka/kafka-deployment.yaml
@@ -1,0 +1,62 @@
+# ktb-bootcampchat-kafka-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktb-bootcampchat-kafka
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: kafka
+spec:
+  replicas: 3  # 고가용성을 위한 3개의 브로커
+  selector:
+    matchLabels:
+      app: ktb-bootcampchat
+      component: kafka
+  template:
+    metadata:
+      labels:
+        app: ktb-bootcampchat
+        component: kafka
+    spec:
+      containers:
+        - name: ktb-bootcampchat-kafka
+          image: confluentinc/cp-kafka:7.4.0
+          ports:
+            - name: internal
+              containerPort: 9092
+            - name: external
+              containerPort: 29092
+          env:
+            - name: KAFKA_BROKER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: "ktb-bootcampchat-zookeeper:2181"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INTERNAL://$(POD_NAME).ktb-bootcampchat-kafka:9092,EXTERNAL://$(POD_IP):29092"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTERNAL"
+          envFrom:
+            - configMapRef:
+                name: ktb-bootcampchat-config
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          livenessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 15
+            periodSeconds: 5

--- a/kubernetes/backend/messaging/kafka/kakfa-service.yaml
+++ b/kubernetes/backend/messaging/kafka/kakfa-service.yaml
@@ -1,0 +1,23 @@
+# ktb-bootcampchat-kafka-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-kafka
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: kafka
+spec:
+  type: ClusterIP
+  ports:
+    - name: internal
+      port: 9092
+      targetPort: 9092
+      protocol: TCP
+    - name: external
+      port: 29092
+      targetPort: 29092
+      protocol: TCP
+  selector:
+    app: ktb-bootcampchat
+    component: kafka

--- a/kubernetes/backend/messaging/zookeeper/zookeeper-deployment.yaml
+++ b/kubernetes/backend/messaging/zookeeper/zookeeper-deployment.yaml
@@ -1,0 +1,53 @@
+# ktb-bootcampchat-zookeeper-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktb-bootcampchat-zookeeper
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: zookeeper
+spec:
+  replicas: 1  # ZooKeeper는 단일 노드로 운영 (개발 환경)
+  selector:
+    matchLabels:
+      app: ktb-bootcampchat
+      component: zookeeper
+  template:
+    metadata:
+      labels:
+        app: ktb-bootcampchat
+        component: zookeeper
+    spec:
+      containers:
+        - name: ktb-bootcampchat-zookeeper
+          image: confluentinc/cp-zookeeper:7.4.0
+          ports:
+            - containerPort: 2181
+              name: client
+            - containerPort: 2888
+              name: server
+            - containerPort: 3888
+              name: leader-election
+          env:
+            - name: ZOOKEEPER_CLIENT_PORT
+              value: "2181"
+            - name: ZOOKEEPER_TICK_TIME
+              value: "2000"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            tcpSocket:
+              port: 2181
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 2181
+            initialDelaySeconds: 15
+            periodSeconds: 5

--- a/kubernetes/backend/messaging/zookeeper/zookeeper-service.yaml
+++ b/kubernetes/backend/messaging/zookeeper/zookeeper-service.yaml
@@ -1,0 +1,27 @@
+# ktb-bootcampchat-zookeeper-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-zookeeper
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: zookeeper
+spec:
+  type: ClusterIP
+  ports:
+    - name: client
+      port: 2181
+      targetPort: 2181
+      protocol: TCP
+    - name: server
+      port: 2888
+      targetPort: 2888
+      protocol: TCP
+    - name: leader-election
+      port: 3888
+      targetPort: 3888
+      protocol: TCP
+  selector:
+    app: ktb-bootcampchat
+    component: zookeeper

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -1,0 +1,23 @@
+# ktb-bootcampchat-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ktb-bootcampchat-config
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+data:
+  # 백엔드 일반 설정
+  MONGO_HOST: "ktb-bootcampchat-mongodb"
+  MONGO_PORT: "27017"
+  MONGO_DATABASE: "bootcampchat"
+  REDIS_HOST: "ktb-bootcampchat-redis"
+  REDIS_PORT: "6379"
+  SERVER_PORT: "5000"
+
+  # 프론트엔드 일반 설정
+  NEXT_PUBLIC_API_URL: "http://ktb-bootcampchat-backend:5000"
+
+  # 공통 환경 설정
+  NODE_ENV: "production"
+  LOG_LEVEL: "info"

--- a/kubernetes/databases/mongo/mongodb-deployment.yaml
+++ b/kubernetes/databases/mongo/mongodb-deployment.yaml
@@ -1,0 +1,56 @@
+# ktb-bootcampchat-mongodb-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktb-bootcampchat-mongodb
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: mongodb
+spec:
+  replicas: 1  # MongoDB는 상태 유지가 필요하므로 단일 레플리카로 운영합니다
+  selector:
+    matchLabels:
+      app: ktb-bootcampchat
+      component: mongodb
+  template:
+    metadata:
+      labels:
+        app: ktb-bootcampchat
+        component: mongodb
+    spec:
+      containers:
+        - name: ktb-bootcampchat-mongodb
+          image: mongo:6.0  # 안정적인 LTS 버전 사용
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          volumeMounts:
+            - name: mongodb-storage
+              mountPath: /data/db
+          envFrom:
+            - configMapRef:
+                name: ktb-bootcampchat-config
+            - secretRef:
+                name: ktb-bootcampchat-secret
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 15
+            periodSeconds: 5
+      volumes:
+        - name: mongodb-storage
+          persistentVolumeClaim:
+            claimName: ktb-bootcampchat-mongodb-pvc

--- a/kubernetes/databases/mongo/mongodb-pv.yaml
+++ b/kubernetes/databases/mongo/mongodb-pv.yaml
@@ -1,0 +1,20 @@
+# ktb-bootcampchat-mongodb-pv.yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ktb-bootcampchat-mongodb-pv
+  labels:
+    app: ktb-bootcampchat
+    component: mongodb
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard
+  hostPath:
+    path: /data/ktb-bootcampchat/mongodb
+    type: DirectoryOrCreate

--- a/kubernetes/databases/mongo/mongodb-pvc.yaml
+++ b/kubernetes/databases/mongo/mongodb-pvc.yaml
@@ -1,0 +1,16 @@
+# ktb-bootcampchat-mongodb-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ktb-bootcampchat-mongodb-pvc
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: mongodb
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/databases/mongo/mongodb-service.yaml
+++ b/kubernetes/databases/mongo/mongodb-service.yaml
@@ -1,0 +1,19 @@
+# ktb-bootcampchat-mongodb-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-mongodb
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: mongodb
+spec:
+  type: ClusterIP
+  ports:
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
+      name: mongodb
+  selector:
+    app: ktb-bootcampchat
+    component: mongodb

--- a/kubernetes/databases/redis/redis-deployment.yaml
+++ b/kubernetes/databases/redis/redis-deployment.yaml
@@ -1,0 +1,56 @@
+# ktb-bootcampchat-redis-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktb-bootcampchat-redis
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: redis
+spec:
+  replicas: 1  # Redis는 상태 유지가 필요하므로 단일 레플리카로 운영
+  selector:
+    matchLabels:
+      app: ktb-bootcampchat
+      component: redis
+  template:
+    metadata:
+      labels:
+        app: ktb-bootcampchat
+        component: redis
+    spec:
+      containers:
+        - name: ktb-bootcampchat-redis
+          image: redis:7.2-alpine  # 안정적인 Alpine 기반 이미지 사용
+          ports:
+            - containerPort: 6379
+              name: redis
+          volumeMounts:
+            - name: redis-storage
+              mountPath: /data  # Redis 데이터 저장 경로
+          envFrom:
+            - configMapRef:
+                name: ktb-bootcampchat-config
+            - secretRef:
+                name: ktb-bootcampchat-secret
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 15
+            periodSeconds: 5
+      volumes:
+        - name: redis-storage
+          persistentVolumeClaim:
+            claimName: ktb-bootcampchat-redis-pvc

--- a/kubernetes/databases/redis/redis-pv.yaml
+++ b/kubernetes/databases/redis/redis-pv.yaml
@@ -1,0 +1,20 @@
+# ktb-bootcampchat-redis-pv.yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ktb-bootcampchat-redis-pv
+  labels:
+    app: ktb-bootcampchat
+    component: redis
+    type: local
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard
+  hostPath:
+    path: /data/ktb-bootcampchat/redis
+    type: DirectoryOrCreate

--- a/kubernetes/databases/redis/redis-pvc.yaml
+++ b/kubernetes/databases/redis/redis-pvc.yaml
@@ -1,0 +1,16 @@
+# ktb-bootcampchat-redis-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ktb-bootcampchat-redis-pvc
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/databases/redis/redis-service.yaml
+++ b/kubernetes/databases/redis/redis-service.yaml
@@ -1,0 +1,19 @@
+# ktb-bootcampchat-redis-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-redis
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+  selector:
+    app: ktb-bootcampchat
+    component: redis

--- a/kubernetes/frontend/frontend-deployment.yaml
+++ b/kubernetes/frontend/frontend-deployment.yaml
@@ -1,0 +1,50 @@
+# ktb-bootcampchat-frontend-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktb-bootcampchat-frontend
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ktb-bootcampchat
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: ktb-bootcampchat
+        component: frontend
+    spec:
+      containers:
+        - name: ktb-bootcampchat-frontend
+          image: ktb-bootcampchat/frontend:latest
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: ktb-bootcampchat-config
+            - secretRef:
+                name: ktb-bootcampchat-secret
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 5

--- a/kubernetes/frontend/frontend-service.yaml
+++ b/kubernetes/frontend/frontend-service.yaml
@@ -1,0 +1,23 @@
+# ktb-bootcampchat-frontend-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-frontend
+  namespace: ktb-bootcampchat
+  labels:
+    app: ktb-bootcampchat
+    component: frontend
+spec:
+  selector:
+    app: ktb-bootcampchat
+    component: frontend
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 3000
+      protocol: TCP

--- a/kubernetes/ingress/ingress-service.yaml
+++ b/kubernetes/ingress/ingress-service.yaml
@@ -1,0 +1,20 @@
+# ktb-bootcampchat-ingress-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktb-bootcampchat-ingress
+  namespace: ingress-nginx
+spec:
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP

--- a/kubernetes/ingress/ingress.yaml
+++ b/kubernetes/ingress/ingress.yaml
@@ -1,0 +1,42 @@
+# ktb-bootcampchat-ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ktb-bootcampchat-ingress
+  namespace: ktb-bootcampchat
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ktb-bootcampchat.site # 도메인 미정
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ktb-bootcampchat-frontend
+                port:
+                  number: 3000
+
+          - path: /api(/.*)?
+            pathType: Prefix
+            backend:
+              service:
+                name: ktb-bootcampchat-backend
+                port:
+                  number: 5000
+
+    - host: api.ktb-bootcampchat.site
+      http:
+        paths:
+          - path: /(docs|openapi.json)
+            pathType: Prefix
+            backend:
+              service:
+                name: ktb-bootcampchat-backend
+                port:
+                  number: 5000


### PR DESCRIPTION
- k8s 매니페스트 파일 작성
- 카프카와 주키퍼를 별도의 서비스로 분리했습니다
- 남기 말로는 각 디비 서비스를 각각 3개로 (카프카 3, 레디스 3, 몽고 3.. 주키퍼 3? (이건 고민) )
- 마스터, 슬레이브 구조 (마스터 1, 슬레이브 2)
- 다른 디비는 몰라도 카프카는 무조건 3개를 써야함. (클라이언트, 서버, 리더 선출용)